### PR TITLE
chore: build  artifact only when it is needed

### DIFF
--- a/.github/actions/build-storybook/action.yaml
+++ b/.github/actions/build-storybook/action.yaml
@@ -1,0 +1,28 @@
+name: 'Build Storybook'
+description: 'Builds storybook'
+inputs:
+  NODE_ENV:
+    description: 'Target env we are going to build assets'
+    required: true
+    default: 'production'
+runs:
+  using: "composite"
+  steps:
+    - run: |
+          [ -d .ghpages-artifact ] || mkdir .ghpages-artifact,
+      shell: bash
+    - run: NODE_ENV=${{ inputs.NODE_ENV }} npm run build:storybook
+      shell: bash
+
+    - name: Grant permissions for a folder containing artifact (needed for upload-pages-artifact action)
+      run: |
+          chmod -c -R +rX ".ghpages-artifact/" | while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      shell: bash
+
+    - name: Archive GitHub Pages Artifact
+      uses: actions/upload-pages-artifact@v2
+      with:
+          name: github-artifact
+          path: ".ghpages-artifact/storybook"

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -13,16 +13,3 @@ runs:
       shell: bash
     - run: NODE_ENV=${{ inputs.NODE_ENV }} npm run build
       shell: bash
-
-    - name: Grant permissions for a folder containing artifact (needed for upload-pages-artifact action)
-      run: |
-          chmod -c -R +rX ".ghpages-artifact/" | while read line; do
-              echo "::warning title=Invalid file permissions automatically fixed::$line"
-          done
-      shell: bash
-
-    - name: Archive GitHub Pages Artifact
-      uses: actions/upload-pages-artifact@v2
-      with:
-          name: github-artifact
-          path: ".ghpages-artifact/storybook"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,7 +84,7 @@ jobs:
                   node-version-file: .nvmrc
                   cache: "npm"
             - uses: ./.github/actions/install
-            - uses: ./.github/actions/build
+            - uses: ./.github/actions/build-storybook
 
     publishGHPages:
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     },
     "scripts": {
         "build": "lerna run build",
+        "build:storybook": "lerna run build --scope @laverve/games-storybook",
         "lint": "eslint --ext .js,.ts,.tsx,.json *.js lerna.json package.json tsconfig*.json *.ts && lerna run lint",
         "lint:fix": "eslint --fix && lerna run lint -- --fix",
         "lint:staged": "lint-staged && lerna run lint:staged --since=origin/main --concurrency=1",


### PR DESCRIPTION
# Description

This PR attempts to fix issue with building an artifact.
We can build artifact and upload it into artifact's storage only when we need it.

## Type of change

Please add a type of the change itno PR's name:

-   [x] `(patch)` or ` ` - bug fix (non-breaking change which fixes an issue)
-   [ ] `(minor)` - New feature (non-breaking change which adds functionality)
-   [ ] `(major)` - Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

N/A

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules